### PR TITLE
Fixed bug where some emotes wouldn't show their image.

### DIFF
--- a/src/main/resources/public/emoticons.json
+++ b/src/main/resources/public/emoticons.json
@@ -6,7 +6,7 @@
         {
           "width": 27.0,
           "height": 28.0,
-          "url": "assets/txt.png"
+          "url": "/assets/txt.png"
         }
       ]
     },
@@ -18,7 +18,7 @@
         {
           "width": 27.0,
           "height": 28.0,
-          "url": "assets/txt.png"
+          "url": "/assets/txt.png"
         }
       ]
     },
@@ -30,7 +30,7 @@
         {
           "width": 27.0,
           "height": 28.0,
-          "url": "assets/txt.png"
+          "url": "/assets/txt.png"
         }
       ]
     },
@@ -40,7 +40,7 @@
         {
           "width": 27.0,
           "height": 28.0,
-          "url": "assets/txt.png"
+          "url": "/assets/txt.png"
         }
       ]
     },
@@ -50,7 +50,7 @@
         {
           "width": 27.0,
           "height": 28.0,
-          "url": "assets/txt.png"
+          "url": "/assets/txt.png"
         }
       ]
     },
@@ -61,7 +61,7 @@
         {
           "width": 27.0,
           "height": 28.0,
-          "url": "assets/txt.png"
+          "url": "/assets/txt.png"
         }
       ]
     },
@@ -73,7 +73,7 @@
         {
           "width": 27.0,
           "height": 28.0,
-          "url": "assets/txt.png"
+          "url": "/assets/txt.png"
         }
       ]
     },
@@ -89,7 +89,7 @@
         {
           "width": 27.0,
           "height": 28.0,
-          "url": "assets/molly.png"
+          "url": "/assets/molly.png"
         }
       ]
     },
@@ -100,7 +100,7 @@
         {
           "width": 27.0,
           "height": 28.0,
-          "url": "assets/rekt.png"
+          "url": "/assets/rekt.png"
         }
       ]
     },
@@ -111,7 +111,7 @@
         {
           "width": 27.0,
           "height": 28.0,
-          "url": "assets/riot.png"
+          "url": "/assets/riot.png"
         }
       ]
     },
@@ -122,7 +122,7 @@
         {
           "width": 27.0,
           "height": 28.0,
-          "url": "assets/gg.png"
+          "url": "/assets/gg.png"
         }
       ]
     },


### PR DESCRIPTION
This happened on the emote-specific page, and happened due to image URLs that pointed to local assets used relative paths where an absolute path was needed.

Example of broken page: [( ͡° ͜ʖ ͡°)](http://kappa.ws/emote/%28%20%CD%A1%C2%B0%20%CD%9C%CA%96%20%CD%A1%C2%B0%29)
